### PR TITLE
Update COM wrappers to be AoT-compatible

### DIFF
--- a/src/TabTip.Avalonia/TabTip/WindowsTabTip.cs
+++ b/src/TabTip.Avalonia/TabTip/WindowsTabTip.cs
@@ -1,56 +1,59 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using System.Runtime.Versioning;
 
 namespace TabTip.Avalonia.TabTip;
 
 [SupportedOSPlatform("windows")]
-public class WindowsTabTip : ITabTip
+public partial class WindowsTabTip : ITabTip
 {
+    private static readonly Guid UIHostNoLaunch_ClsId = new Guid("4ce576fa-83dc-4F88-951c-9d0782b4e376");
+    private const string ITipInvocation_IIdRaw = "37c994e7-432b-4834-a2f7-dce1f13b834b";
+    private static readonly Guid ITipInvocation_IId = new Guid(ITipInvocation_IIdRaw);
+
+    private const int ClassNotRegistered = unchecked((int)0x80040154);
+    private const uint CLSCTX_LOCAL_SERVER = 0x4;
+
     public IHardwareKeyboard Keyboard { get; } = new WindowsHardwareKeyboard();
     public ISessionInfo Session { get; } = new WindowsSessionInfo();
 
     public void Toggle(IntPtr hwnd)
     {
-        UIHostNoLaunch uiHostNoLaunch;
-        try
-        {
-            uiHostNoLaunch = new UIHostNoLaunch();
-        }
-        catch(COMException e)
+        int hr = Ole32.CoCreateInstance(UIHostNoLaunch_ClsId, 0, CLSCTX_LOCAL_SERVER, ITipInvocation_IId, out nint ptr);
+        if (hr == ClassNotRegistered)
         {
             // The process was not started before, so we start it.
-            if ((uint)e.HResult == 0x80040154)
+            Process p = new()
             {
-                Process p = new()
+                StartInfo = new ProcessStartInfo
                 {
-                    StartInfo = new ProcessStartInfo
-                    {
-                        FileName = "tabtip.exe",
-                        UseShellExecute = true
-                    }
-                };
-                p.Start();
-            }
-            else
-                throw;
-
+                    FileName = "tabtip.exe",
+                    UseShellExecute = true
+                }
+            };
+            p.Start();
             return;
         }
+        else Marshal.ThrowExceptionForHR(hr);
+
+        var comWrappers = new StrategyBasedComWrappers();
 
         // ReSharper disable once SuspiciousTypeConversion.Global
-        var tipInvocation = (ITipInvocation)uiHostNoLaunch;
+        var tipInvocation = (ITipInvocation)comWrappers.GetOrCreateObjectForComInstance(ptr, CreateObjectFlags.None);
         tipInvocation.Toggle(hwnd);
-        Marshal.ReleaseComObject(uiHostNoLaunch);
+        Marshal.Release(ptr);
     }
-    
-    [ComImport, Guid("4ce576fa-83dc-4F88-951c-9d0782b4e376")]
-    private class UIHostNoLaunch;
 
-    [ComImport, Guid("37c994e7-432b-4834-a2f7-dce1f13b834b")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    private interface ITipInvocation
+    [GeneratedComInterface, Guid(ITipInvocation_IIdRaw)]
+    internal partial interface ITipInvocation
     {
         void Toggle(IntPtr hwnd);
+    }
+
+    internal static partial class Ole32
+    {
+        [LibraryImport("ole32.dll")]
+        public static partial int CoCreateInstance(Guid rclsid, nint pUnkOuter, uint dwClsContext, Guid riid, out nint ppv);
     }
 }


### PR DESCRIPTION
`ComImport` is not compatible with ahead-of-time compilation. If the current version of the library is used in an application which is compiled with AoT, it fails at runtime with a crash

       at Internal.Runtime.TypeLoaderExceptionHelper.CreateInvalidProgramException(ExceptionStringID, String) + 0x40
       at TabTip.Avalonia.TabTip.WindowsTabTip.UIHostNoLaunch..ctor() + 0x15
       at TabTip.Avalonia.TabTip.WindowsTabTip.Toggle(IntPtr) + 0x26

This PR replaces `ComImport` with `GeneratedComInterface` and the instantiation of `UIHostNoLaunch` with a call to `Ole32.CoCreateInstance`. I have tested it successfully under AoT.