### PR TITLE
fix cleanup leak

### DIFF
--- a/src/TabTip.Avalonia/TabTipIntegration.cs
+++ b/src/TabTip.Avalonia/TabTipIntegration.cs
@@ -151,7 +151,7 @@ public class TabTipIntegration(ITabTip tabTip) : ITabTipIntegration
 
         Control.UnloadedEvent.AddClassHandler<TopLevel>((s, e) =>
         {
-            var input = s.InputPane;
+            var input = tlMap.FirstOrDefault(x => x.Value == s).Key;
             if (input == null)
                 return;
 


### PR DESCRIPTION
`InputPane` is already nulled on the `TopLevel` by the time `UnloadedEvent` fires. The event + dictionary entry are never cleaned up. Since the number of toplevels is expected to be limited searching the dictionary by value is reasonable.

fixes #17 

before

<img width="1525" height="190" alt="memory-leak-unfixed" src="https://github.com/user-attachments/assets/1b690a3a-52a3-4ac0-9820-0f0575c39f83" />

after

<img width="1525" height="201" alt="memory-leak-fixed" src="https://github.com/user-attachments/assets/2c37db45-84f8-4769-aa74-cf66dba2e270" />


